### PR TITLE
feat: add endpoint to delete post

### DIFF
--- a/api/v1/routes/post.py
+++ b/api/v1/routes/post.py
@@ -25,3 +25,20 @@ async def create_post(
         message="Post created successfully",
         data=new_post,
     )
+
+
+@posts.delete(
+    "/{id}",
+    summary="Delete a post",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_post(
+    id: str,
+    db: Session = Depends(get_db),
+    user: User = Depends(user_service.get_current_user),
+):
+    post_service.delete(db=db, user=user, post_id=id)
+
+    return success_response(
+        status_code=status.HTTP_204_NO_CONTENT, message="Post deleted successfully"
+    )

--- a/api/v1/services/post.py
+++ b/api/v1/services/post.py
@@ -24,5 +24,20 @@ class PostService:
 
         return jsonable_encoder(post)
 
+    def delete(self, db: Session, user: User, post_id: str):
+        # get post matching post_id and user
+
+        post = (
+            db.query(Post).filter(Post.user_id == user.id, Post.id == post_id).first()
+        )
+
+        if not post:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Post not found"
+            )
+
+        db.delete(post)
+        db.commit()
+
 
 post_service = PostService()

--- a/api/v1/tests/post/conftest.py
+++ b/api/v1/tests/post/conftest.py
@@ -6,14 +6,10 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
 )
 
-from fastapi import HTTPException, status
+from fastapi import HTTPException
 import pytest
 from uuid import uuid4
-from main import app
-from unittest.mock import patch, MagicMock
-from api.v1.utils.dependencies import get_db
-from api.v1.services.user import user_service
-from api.v1.models.user import User
+from unittest.mock import patch
 
 mock_id = str(uuid4())
 
@@ -32,3 +28,11 @@ def mock_create_post():
         }
 
         yield create_post
+
+
+@pytest.fixture
+def mock_delete_post_side_effect():
+    with patch("api.v1.services.post.post_service.delete") as create_post_side_effect:
+        create_post_side_effect.side_effect = HTTPException(404, "Post not found")
+
+        yield create_post_side_effect

--- a/api/v1/tests/post/test_delete_post.py
+++ b/api/v1/tests/post/test_delete_post.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../"))
+)
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+from main import app
+
+client = TestClient(app)
+endpoint = "api/v1/posts/xx-yy-zz"
+
+
+def test_delete_post_success(
+    mock_db_session: Session, access_token, current_user, mock_create_post
+):
+    response = client.delete(
+        endpoint, headers={"authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 204
+    assert response.json()["status_code"] == 204
+    assert response.json()["message"] == "Post deleted successfully"
+
+
+def test_delete_post_not_found(
+    mock_db_session: Session,
+    access_token,
+    current_user,
+    mock_delete_post_side_effect
+):
+    response = client.delete(
+        endpoint, headers={"authorization": f"Bearer {access_token}"}
+    )
+
+    assert response.status_code == 404
+    assert response.json()["status_code"] == 404
+    assert response.json()["message"] == "Post not found"
+
+
+def test_create_post_unauthenticated_user(
+    mock_db_session: Session,
+):
+    response = client.delete(endpoint)
+
+    assert response.status_code == 401


### PR DESCRIPTION
#### Related Issue (Link to issue ticket)
---

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This feature is related to #49 

#### Description
---

<!--- Describe your changes in detail -->

- Added endpoint to delete a post
- Returns `204` on success
- Added tests to cover new endpoint


#### How Has This Been Tested? Screenshots (if appropriate - Postman, etc)
---

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```shell
============================= test session starts =============================
platform win32 -- Python 3.10.7, pytest-8.2.2, pluggy-1.5.0 -- C:\Users\HP\OneDrive\Desktop\codes\fast-api-social-media-api\venv\Scripts\python.exe
cachedir: .pytest_cache
rootdir: C:\Users\HP\OneDrive\desktop\Codes\fast-api-social-media-api
plugins: anyio-4.4.0
collecting ... collected 22 items

api/v1/tests/auth/test_user_login.py::test_login_success PASSED          [  4%]
api/v1/tests/auth/test_user_login.py::test_incorrect_email PASSED        [  9%]
api/v1/tests/auth/test_user_login.py::test_incorrect_password PASSED     [ 13%]
api/v1/tests/auth/test_user_logout.py::test_logout_success PASSED        [ 18%]
api/v1/tests/auth/test_user_registration_endpoint.py::test_register_user_success PASSED [ 22%]
api/v1/tests/auth/test_user_registration_endpoint.py::test_register_validation_error PASSED [ 27%]
api/v1/tests/auth/test_user_registration_endpoint.py::test_user_already_exist PASSED [ 31%]
api/v1/tests/post/test_create_post.py::test_create_post_success PASSED   [ 36%]
api/v1/tests/post/test_create_post.py::test_create_post_invalid_content PASSED [ 40%]
api/v1/tests/post/test_create_post.py::test_create_post_unauthenticated_user PASSED [ 45%]
api/v1/tests/post/test_delete_post.py::test_delete_post_success PASSED   [ 50%]
api/v1/tests/post/test_delete_post.py::test_delete_post_not_found PASSED [ 54%]
api/v1/tests/post/test_delete_post.py::test_create_post_unauthenticated_user PASSED [ 59%]
api/v1/tests/test_root.py::test_server_root PASSED                       [ 63%]
api/v1/tests/test_root.py::test_404_not_found_error PASSED               [ 68%]
api/v1/tests/test_root.py::test_other_error_response PASSED              [ 72%]
api/v1/tests/user/test_delete_user.py::test_delete_user PASSED           [ 77%]
api/v1/tests/user/test_delete_user.py::test_delete_user_permission_denied PASSED [ 81%]
api/v1/tests/user/test_get_users.py::test_get_user_detail PASSED         [ 86%]
api/v1/tests/user/test_update_user.py::test_update_user_profile PASSED   [ 90%]
api/v1/tests/user/test_update_user.py::test_update_user_side_effect PASSED [ 95%]
api/v1/tests/user/test_user_detail.py::test_get_user_detail PASSED       [100%]

============================= 22 passed in 10.46s =============================
```
​

#### Types of changes
---

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
      ​

#### Checklist:
---

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
